### PR TITLE
🔒 [P1 CRITICAL] Remove Password Hash Exposure from API Responses

### DIFF
--- a/server/discourse-sso.ts
+++ b/server/discourse-sso.ts
@@ -230,7 +230,7 @@ export async function getUserWithDiscourse(userId: number): Promise<SharedUserWi
         id: sharedUsers.id,
         username: sharedUsers.username,
         email: sharedUsers.email,
-        passwordHash: sharedUsers.passwordHash,
+        // SECURITY: Never expose passwordHash
         discourseUserId: sharedUsers.discourseUserId,
         role: sharedUsers.role,
         bio: sharedUsers.bio,
@@ -249,14 +249,14 @@ export async function getUserWithDiscourse(userId: number): Promise<SharedUserWi
       .leftJoin(discourseUserMapping, eq(sharedUsers.id, discourseUserMapping.priceAppUserId))
       .where(eq(sharedUsers.id, userId))
       .limit(1);
-    
+
     if (!user) return null;
-    
+
     const result: SharedUserWithDiscourse = {
       id: user.id,
       username: user.username,
       email: user.email,
-      passwordHash: user.passwordHash,
+      passwordHash: '', // SECURITY: Never expose - empty string to satisfy type
       discourseUserId: user.discourseUserId,
       role: user.role,
       bio: user.bio,

--- a/server/forum-storage.ts
+++ b/server/forum-storage.ts
@@ -184,7 +184,7 @@ export class ForumStorage {
           id: users.id,
           username: users.username,
           email: users.email,
-          passwordHash: users.passwordHash,
+          // SECURITY: Never expose passwordHash
           createdAt: users.createdAt,
           updatedAt: users.updatedAt,
         }


### PR DESCRIPTION
## Summary

**CRITICAL SECURITY FIX** - Fixes GitHub issue #57

Removed password hash exposure from API responses in forum and SSO endpoints.

### Changes Made

✅ **Removed passwordHash from forum-storage.ts:187**
- Forum post author query no longer exposes passwordHash
- Added explicit security comment to prevent future exposure

✅ **Removed passwordHash from discourse-sso.ts:233,259**  
- Discourse SSO user query no longer includes passwordHash in SELECT
- Returns empty string to satisfy type requirements without exposing real hash

✅ **Strengthened pre-commit hook**
- Enhanced passwordHash detection to show more detailed information
- Better guards against future accidental exposures

### Impact

**Before:**
```typescript
// ❌ EXPOSED passwordHash in API response
author: {
  id: users.id,
  username: users.username,
  passwordHash: users.passwordHash,  // Exposed!
  ...
}
```

**After:**
```typescript
// ✅ SECURE - passwordHash never exposed
author: {
  id: users.id,
  username: users.username,
  // SECURITY: Never expose passwordHash
  ...
}
```

### Security Impact

- **Prevents offline brute-force attacks** on user passwords
- **Addresses GDPR Article 32 violation** (inadequate data protection)
- **Follows principle of least privilege** - only return needed fields
- **CVSS Score: 8.1 (High/Critical)** - Now resolved

### Testing

✅ Grep audit confirms no unsafe passwordHash exposures
✅ Only INSERT/UPDATE operations reference passwordHash (safe)
✅ Pre-commit hook successfully blocks future exposures
✅ TypeScript type checking passed for modified files

### Acceptance Criteria

- [x] Remove passwordHash from forum-storage.ts:187
- [x] Remove passwordHash from discourse-sso.ts:233,259
- [x] Run grep audit - 0 unsafe results
- [x] Strengthen pre-commit hook to prevent future exposures
- [ ] Review and merge PR

### Related Issues

Closes #57

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)