### PR TITLE
Migrate 3 services to storage layer (Phase 1 of TODO #031)

### DIFF
--- a/server/services/affiliate-link-service.ts
+++ b/server/services/affiliate-link-service.ts
@@ -1,6 +1,4 @@
-import { db } from '../db';
-import { retailers, productOffers } from '../../shared/schema';
-import { eq, sql, count } from 'drizzle-orm';
+import { storage, type AffiliateLinkStats } from '../storage';
 import type { Retailer } from '../../shared/schema';
 import { createLogger } from '../utils/logger';
 
@@ -43,7 +41,7 @@ export class AffiliateLinkService {
   ): Promise<LinkGenerationResult> {
     try {
       const retailer = await this.getRetailerConfig(retailerId);
-      
+
       if (!retailer || retailer.affiliateStatus !== 'active') {
         return {
           success: false,
@@ -53,7 +51,7 @@ export class AffiliateLinkService {
       }
 
       const affiliateUrl = await this.transformUrl(retailer, productUrl, metadata);
-      
+
       if (affiliateUrl) {
         return {
           success: true,
@@ -94,19 +92,19 @@ export class AffiliateLinkService {
     switch (retailer.affiliateProgram) {
       case 'amazon_associates':
         return this.generateAmazonLink(productUrl, config, productId);
-      
+
       case 'walmart_connect':
         return this.generateWalmartLink(productUrl, config, productId);
-      
+
       case 'target_partners':
         return this.generateTargetLink(productUrl, config);
-      
+
       case 'bestbuy_affiliate':
         return this.generateBestBuyLink(productUrl, config);
-      
+
       case 'generic_utm':
         return this.addUTMTracking(productUrl, retailer.name, config);
-      
+
       default:
         return null;
     }
@@ -166,15 +164,15 @@ export class AffiliateLinkService {
    * Add UTM tracking parameters
    */
   private addUTMTracking(
-    url: string, 
-    retailerName: string, 
+    url: string,
+    retailerName: string,
     config?: AffiliateConfig
   ): string {
     const separator = url.includes('?') ? '&' : '?';
     const source = config?.source || 'pricecompare';
     const campaign = config?.campaign || 'product';
     const medium = config?.medium || 'affiliate';
-    
+
     return `${url}${separator}utm_source=${source}&utm_medium=${medium}&utm_campaign=${campaign}&utm_content=${retailerName.toLowerCase()}`;
   }
 
@@ -198,10 +196,7 @@ export class AffiliateLinkService {
     }
 
     try {
-      const [retailer] = await db.select()
-        .from(retailers)
-        .where(eq(retailers.id, retailerId))
-        .limit(1);
+      const retailer = await storage.getRetailerById(retailerId);
 
       if (retailer) {
         this.retailerCache.set(retailerId, retailer);
@@ -236,13 +231,13 @@ export class AffiliateLinkService {
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 5000);
-      
-      const response = await fetch(affiliateUrl, { 
+
+      const response = await fetch(affiliateUrl, {
         method: 'HEAD',
         redirect: 'follow',
         signal: controller.signal
       });
-      
+
       clearTimeout(timeoutId);
       return response.ok;
     } catch (error) {
@@ -255,18 +250,16 @@ export class AffiliateLinkService {
    * Update product offer with affiliate URL
    */
   async updateOfferWithAffiliateLink(
-    offerId: number, 
-    affiliateUrl: string, 
+    offerId: number,
+    affiliateUrl: string,
     isHealthy: boolean = true
   ): Promise<void> {
     try {
-      await db.update(productOffers)
-        .set({
-          affiliateUrl,
-          linkHealthStatus: isHealthy ? 'healthy' : 'broken',
-          lastLinkCheck: new Date()
-        })
-        .where(eq(productOffers.id, offerId));
+      await storage.updateProductOfferAffiliateLink(offerId, {
+        affiliateUrl,
+        linkHealthStatus: isHealthy ? 'healthy' : 'broken',
+        lastLinkCheck: new Date()
+      });
     } catch (error) {
       log.error('Failed to update offer with affiliate link:', { error });
     }
@@ -277,18 +270,7 @@ export class AffiliateLinkService {
    */
   async trackLinkClick(offerId: number): Promise<void> {
     try {
-      const [offer] = await db.select()
-        .from(productOffers)
-        .where(eq(productOffers.id, offerId))
-        .limit(1);
-
-      if (offer) {
-        await db.update(productOffers)
-          .set({
-            clickCount: (offer.clickCount || 0) + 1
-          })
-          .where(eq(productOffers.id, offerId));
-      }
+      await storage.incrementProductOfferClickCount(offerId);
     } catch (error) {
       log.error('Failed to track link click:', { error });
     }
@@ -303,9 +285,7 @@ export class AffiliateLinkService {
     broken: number;
   }> {
     try {
-      const offers = await db.select()
-        .from(productOffers)
-        .where(eq(productOffers.retailerId, retailerId));
+      const offers = await storage.getProductOffersByRetailerId(retailerId);
 
       let healthy = 0;
       let broken = 0;
@@ -313,9 +293,9 @@ export class AffiliateLinkService {
       for (const offer of offers) {
         if (offer.affiliateUrl) {
           const isHealthy = await this.validateAffiliateLink(offer.affiliateUrl);
-          
+
           await this.updateOfferWithAffiliateLink(offer.id, offer.affiliateUrl, isHealthy);
-          
+
           if (isHealthy) {
             healthy++;
           } else {
@@ -345,36 +325,9 @@ export class AffiliateLinkService {
   /**
    * Get affiliate link statistics
    */
-  async getAffiliateLinkStats(retailerId?: number): Promise<{
-    total_offers: number;
-    affiliate_offers: number;
-    total_clicks: number;
-    healthy_links: number;
-    broken_links: number;
-  } | null> {
+  async getAffiliateLinkStats(retailerId?: number): Promise<AffiliateLinkStats | null> {
     try {
-      // Use Drizzle ORM for safe query building
-      const baseQuery = db
-        .select({
-          total_offers: count(),
-          affiliate_offers: sql<number>`COUNT(${productOffers.affiliateUrl})`,
-          total_clicks: sql<number>`COALESCE(SUM(${productOffers.clickCount}), 0)`,
-          healthy_links: sql<number>`COUNT(CASE WHEN ${productOffers.linkHealthStatus} = 'healthy' THEN 1 END)`,
-          broken_links: sql<number>`COUNT(CASE WHEN ${productOffers.linkHealthStatus} = 'broken' THEN 1 END)`,
-        })
-        .from(productOffers);
-
-      const result = retailerId
-        ? await baseQuery.where(eq(productOffers.retailerId, retailerId))
-        : await baseQuery;
-
-      return result[0] || {
-        total_offers: 0,
-        affiliate_offers: 0,
-        total_clicks: 0,
-        healthy_links: 0,
-        broken_links: 0
-      };
+      return await storage.getAffiliateLinkStats(retailerId);
     } catch (error) {
       log.error('Failed to get affiliate link stats:', { error });
       return null;

--- a/server/services/job-lock-service.ts
+++ b/server/services/job-lock-service.ts
@@ -1,6 +1,4 @@
-import { db } from "../db";
-import { jobLocks } from "../../shared/schema";
-import { eq, and, lte, sql } from "drizzle-orm";
+import { storage } from "../storage";
 import { logger } from "../utils/logger";
 import os from "os";
 import crypto from "crypto";
@@ -42,18 +40,9 @@ export class JobLockService {
       const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
 
       // Try to insert a new lock
-      const result = await db
-        .insert(jobLocks)
-        .values({
-          jobName,
-          lockedBy: this.instanceId,
-          expiresAt,
-          lockedAt: new Date(),
-        })
-        .onConflictDoNothing() // If lock exists, do nothing
-        .returning({ id: jobLocks.id });
+      const result = await storage.acquireJobLock(jobName, this.instanceId, ttlSeconds);
 
-      if (result.length > 0) {
+      if (result.success) {
         logger.info(`[JobLock] Acquired lock for job "${jobName}"`, {
           instanceId: this.instanceId,
           expiresAt: expiresAt.toISOString(),
@@ -62,44 +51,25 @@ export class JobLockService {
       }
 
       // Lock already exists, check if it's ours or expired
-      const existingLock = await db
-        .select()
-        .from(jobLocks)
-        .where(eq(jobLocks.jobName, jobName))
-        .limit(1);
+      const existingLock = await storage.getJobLockByName(jobName);
 
-      if (existingLock.length > 0) {
-        const lock = existingLock[0];
-
+      if (existingLock) {
         // Check if lock is expired
-        if (new Date(lock.expiresAt) < new Date()) {
+        if (new Date(existingLock.expiresAt) < new Date()) {
           // Try to acquire expired lock
-          const updated = await db
-            .update(jobLocks)
-            .set({
-              lockedBy: this.instanceId,
-              lockedAt: new Date(),
-              expiresAt,
-            })
-            .where(
-              and(
-                eq(jobLocks.jobName, jobName),
-                lte(jobLocks.expiresAt, new Date()) // Only update if still expired
-              )
-            )
-            .returning({ id: jobLocks.id });
+          const updated = await storage.updateExpiredJobLock(jobName, this.instanceId, expiresAt);
 
-          if (updated.length > 0) {
+          if (updated.success) {
             logger.info(`[JobLock] Acquired expired lock for job "${jobName}"`, {
               instanceId: this.instanceId,
-              previousOwner: lock.lockedBy,
+              previousOwner: existingLock.lockedBy,
             });
             return true;
           }
         }
 
-        logger.debug(`[JobLock] Job "${jobName}" is already locked by "${lock.lockedBy}"`, {
-          expiresAt: lock.expiresAt,
+        logger.debug(`[JobLock] Job "${jobName}" is already locked by "${existingLock.lockedBy}"`, {
+          expiresAt: existingLock.expiresAt,
         });
         return false;
       }
@@ -121,17 +91,9 @@ export class JobLockService {
    */
   async releaseLock(jobName: string): Promise<boolean> {
     try {
-      const result = await db
-        .delete(jobLocks)
-        .where(
-          and(
-            eq(jobLocks.jobName, jobName),
-            eq(jobLocks.lockedBy, this.instanceId)
-          )
-        )
-        .returning({ id: jobLocks.id });
+      const released = await storage.releaseJobLock(jobName, this.instanceId);
 
-      if (result.length > 0) {
+      if (released) {
         logger.info(`[JobLock] Released lock for job "${jobName}"`, {
           instanceId: this.instanceId,
         });
@@ -160,20 +122,9 @@ export class JobLockService {
    */
   async extendLock(jobName: string, additionalSeconds: number): Promise<boolean> {
     try {
-      const result = await db
-        .update(jobLocks)
-        .set({
-          expiresAt: sql`${jobLocks.expiresAt} + INTERVAL '${sql.raw(additionalSeconds.toString())} seconds'`,
-        })
-        .where(
-          and(
-            eq(jobLocks.jobName, jobName),
-            eq(jobLocks.lockedBy, this.instanceId)
-          )
-        )
-        .returning({ id: jobLocks.id });
+      const extended = await storage.extendJobLock(jobName, this.instanceId, additionalSeconds);
 
-      if (result.length > 0) {
+      if (extended) {
         logger.debug(`[JobLock] Extended lock for job "${jobName}" by ${additionalSeconds}s`);
         return true;
       }
@@ -195,18 +146,7 @@ export class JobLockService {
    */
   async isLocked(jobName: string): Promise<boolean> {
     try {
-      const locks = await db
-        .select({ id: jobLocks.id })
-        .from(jobLocks)
-        .where(
-          and(
-            eq(jobLocks.jobName, jobName),
-            sql`${jobLocks.expiresAt} > NOW()` // Not expired
-          )
-        )
-        .limit(1);
-
-      return locks.length > 0;
+      return await storage.isJobLocked(jobName);
     } catch (error) {
       logger.error(`[JobLock] Error checking lock for job "${jobName}":`, {
         error: error instanceof Error ? error.message : String(error),
@@ -221,16 +161,13 @@ export class JobLockService {
    */
   async cleanupExpiredLocks(): Promise<number> {
     try {
-      const result = await db
-        .delete(jobLocks)
-        .where(lte(jobLocks.expiresAt, new Date()))
-        .returning({ id: jobLocks.id });
+      const cleanedCount = await storage.cleanupExpiredJobLocks();
 
-      if (result.length > 0) {
-        logger.info(`[JobLock] Cleaned up ${result.length} expired locks`);
+      if (cleanedCount > 0) {
+        logger.info(`[JobLock] Cleaned up ${cleanedCount} expired locks`);
       }
 
-      return result.length;
+      return cleanedCount;
     } catch (error) {
       logger.error('[JobLock] Error cleaning up expired locks:', {
         error: error instanceof Error ? error.message : String(error),

--- a/server/services/password-reset-service.ts
+++ b/server/services/password-reset-service.ts
@@ -1,8 +1,9 @@
 import * as crypto from 'crypto';
-import { db } from '../db';
-import { passwordResetTokens, users } from '@shared/schema';
-import { eq, and, gt, lt } from 'drizzle-orm';
+import { storage } from '../storage';
 import type { PasswordResetToken } from '@shared/schema';
+import { db } from '../db';
+import { users } from '@shared/schema';
+import { eq } from 'drizzle-orm';
 
 /**
  * Password Reset Token Service
@@ -34,28 +35,9 @@ export async function createPasswordResetToken(
   const token = generateSecureToken();
   const expiresAt = new Date(Date.now() + TOKEN_EXPIRATION_TIME);
 
-  // SECURITY: Use transaction to ensure old token deletion and new token creation are atomic
-  // If token creation fails after deletion, user has no valid tokens (lockout scenario)
-  await db.transaction(async (tx) => {
-    // Invalidate any existing unused tokens for this user (optional security measure)
-    await tx
-      .delete(passwordResetTokens)
-      .where(
-        and(
-          eq(passwordResetTokens.userId, userId),
-          eq(passwordResetTokens.isUsed, false)
-        )
-      );
-
-    // Create the new token - must succeed or rollback deletion
-    await tx.insert(passwordResetTokens).values({
-      userId,
-      token,
-      expiresAt,
-      isUsed: false,
-      ipAddress: ipAddress?.substring(0, 45), // Ensure it fits in VARCHAR(45)
-      userAgent: userAgent?.substring(0, 500), // Ensure it fits in VARCHAR(500)
-    });
+  await storage.createPasswordResetToken(userId, token, expiresAt, {
+    ipAddress,
+    userAgent,
   });
 
   return token;
@@ -69,15 +51,7 @@ export async function createPasswordResetToken(
 export async function validatePasswordResetToken(
   token: string
 ): Promise<PasswordResetToken | null> {
-  const tokenRecord = await db.query.passwordResetTokens.findFirst({
-    where: and(
-      eq(passwordResetTokens.token, token),
-      eq(passwordResetTokens.isUsed, false),
-      gt(passwordResetTokens.expiresAt, new Date())
-    ),
-  });
-
-  return tokenRecord || null;
+  return storage.validatePasswordResetToken(token);
 }
 
 /**
@@ -85,13 +59,7 @@ export async function validatePasswordResetToken(
  * @param token - The token to mark as used
  */
 export async function markTokenAsUsed(token: string): Promise<void> {
-  await db
-    .update(passwordResetTokens)
-    .set({
-      isUsed: true,
-      usedAt: new Date(),
-    })
-    .where(eq(passwordResetTokens.token, token));
+  await storage.markPasswordResetTokenAsUsed(token);
 }
 
 /**
@@ -100,14 +68,29 @@ export async function markTokenAsUsed(token: string): Promise<void> {
  * @returns The user record if the token is valid, null otherwise
  */
 export async function getUserByResetToken(token: string) {
-  const tokenRecord = await validatePasswordResetToken(token);
+  const tokenRecord = await storage.validatePasswordResetToken(token);
 
   if (!tokenRecord) {
     return null;
   }
 
+  // TODO: This should use a storage method like storage.getUserByIdSafe()
+  // that returns SafeUser instead of exposing passwordHash.
+  // For now, using direct db query with explicit field selection for security.
   const user = await db.query.users.findFirst({
     where: eq(users.id, tokenRecord.userId),
+    columns: {
+      id: true,
+      username: true,
+      email: true,
+      role: true,
+      trustLevel: true,
+      isActive: true,
+      isSuspended: true,
+      createdAt: true,
+      updatedAt: true,
+      // SECURITY: NEVER expose passwordHash
+    },
   });
 
   return user || null;
@@ -118,13 +101,7 @@ export async function getUserByResetToken(token: string) {
  * Removes tokens that have expired or been used
  */
 export async function cleanupExpiredTokens(): Promise<number> {
-  const result = await db
-    .delete(passwordResetTokens)
-    .where(
-      lt(passwordResetTokens.expiresAt, new Date())
-    );
-
-  return result.rowCount || 0;
+  return storage.cleanupExpiredPasswordResetTokens();
 }
 
 /**
@@ -141,15 +118,8 @@ export async function isRateLimitExceeded(
   maxAttempts: number = 3
 ): Promise<boolean> {
   const since = new Date(Date.now() - windowMinutes * 60 * 1000);
-
-  const recentTokens = await db.query.passwordResetTokens.findMany({
-    where: and(
-      eq(passwordResetTokens.userId, userId),
-      gt(passwordResetTokens.createdAt, since)
-    ),
-  });
-
-  return recentTokens.length >= maxAttempts;
+  const count = await storage.getPasswordResetAttemptCount(userId, since);
+  return count >= maxAttempts;
 }
 
 /**
@@ -163,13 +133,5 @@ export async function getResetAttemptCount(
   windowMinutes: number = 15
 ): Promise<number> {
   const since = new Date(Date.now() - windowMinutes * 60 * 1000);
-
-  const recentTokens = await db.query.passwordResetTokens.findMany({
-    where: and(
-      eq(passwordResetTokens.userId, userId),
-      gt(passwordResetTokens.createdAt, since)
-    ),
-  });
-
-  return recentTokens.length;
+  return storage.getPasswordResetAttemptCount(userId, since);
 }

--- a/server/services/password-reset-service.ts
+++ b/server/services/password-reset-service.ts
@@ -1,9 +1,6 @@
 import * as crypto from 'crypto';
 import { storage } from '../storage';
 import type { PasswordResetToken } from '@shared/schema';
-import { db } from '../db';
-import { users } from '@shared/schema';
-import { eq } from 'drizzle-orm';
 
 /**
  * Password Reset Token Service
@@ -74,26 +71,8 @@ export async function getUserByResetToken(token: string) {
     return null;
   }
 
-  // TODO: This should use a storage method like storage.getUserByIdSafe()
-  // that returns SafeUser instead of exposing passwordHash.
-  // For now, using direct db query with explicit field selection for security.
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, tokenRecord.userId),
-    columns: {
-      id: true,
-      username: true,
-      email: true,
-      role: true,
-      trustLevel: true,
-      isActive: true,
-      isSuspended: true,
-      createdAt: true,
-      updatedAt: true,
-      // SECURITY: NEVER expose passwordHash
-    },
-  });
-
-  return user || null;
+  // SECURITY: getUserByIdSafe() never exposes passwordHash
+  return storage.getUserByIdSafe(tokenRecord.userId);
 }
 
 /**

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -63,6 +63,7 @@ export interface IStorage {
   // Users (Admin)
   getAllUsers(): Promise<SafeUser[]>;
   getUserCount(): Promise<number>;
+  getUserByIdSafe(id: number): Promise<SafeUser | null>;
   updateUserProfile(userId: number, updates: { bio?: string; location?: string; website?: string; avatarUrl?: string }): Promise<void>;
   updateUserTrustLevel(userId: number, trustLevel: number): Promise<void>;
   suspendUser(userId: number, reason: string, suspendedBy: number): Promise<void>;
@@ -721,6 +722,10 @@ export class MemStorage implements IStorage {
 
   async getUserCount(): Promise<number> {
     return 0;
+  }
+
+  async getUserByIdSafe(_id: number): Promise<SafeUser | null> {
+    return null;
   }
 
   async updateUserProfile(_userId: number, _updates: { bio?: string; location?: string; website?: string; avatarUrl?: string }): Promise<void> {
@@ -2678,6 +2683,30 @@ export class DatabaseStorage implements IStorage {
     }).from(users);
   }
 
+  async getUserByIdSafe(id: number): Promise<SafeUser | null> {
+    // SECURITY: Never expose passwordHash - explicit field selection
+    const [user] = await db.select({
+      id: users.id,
+      username: users.username,
+      email: users.email,
+      role: users.role,
+      trustLevel: users.trustLevel,
+      isActive: users.isActive,
+      isSuspended: users.isSuspended,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt
+    }).from(users)
+      .where(eq(users.id, id))
+      .limit(1);
+
+    return user || null;
+  }
+
+  async getUserCount(): Promise<number> {
+    const [result] = await db.select({ count: sql<number>`count(*)::int` }).from(users);
+    return result?.count ?? 0;
+  }
+
   async getAdminAnalyticsOverview(): Promise<AdminAnalyticsOverview> {
     const [userCount, topicCount, postCount, categoryCount] = await Promise.all([
       db.select({ count: sql`count(*)` }).from(users),
@@ -3141,7 +3170,7 @@ export class DatabaseStorage implements IStorage {
     const result = await db
       .update(jobLocks)
       .set({
-        expiresAt: sql`${jobLocks.expiresAt} + INTERVAL '${sql.raw(additionalSeconds.toString())} seconds'`,
+        expiresAt: sql`${jobLocks.expiresAt} + (${additionalSeconds} * INTERVAL '1 second')`,
       })
       .where(
         and(
@@ -3237,13 +3266,18 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getPasswordResetAttemptCount(userId: number, sinceDate: Date): Promise<number> {
-    const tokens = await db.query.passwordResetTokens.findMany({
-      where: and(
-        eq(passwordResetTokens.userId, userId),
-        sql`${passwordResetTokens.createdAt} > ${sinceDate}`
-      ),
-    });
-    return tokens.length;
+    // Use COUNT instead of fetching all records for better performance
+    const [result] = await db.select({
+      count: sql<number>`COUNT(*)::int`
+    }).from(passwordResetTokens)
+      .where(
+        and(
+          eq(passwordResetTokens.userId, userId),
+          sql`${passwordResetTokens.createdAt} > ${sinceDate}`
+        )
+      );
+
+    return result?.count ?? 0;
   }
 }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,6 +1,6 @@
-import { retailers, products, productOffers, priceHistory, watchLists, productWatches, priceAlerts, users, forumTopics, forumPosts, forumCategories, trendingProducts, priceAggregatesWeekly, priceAggregatesMonthly, priceTrends, jobLocks, notifications, passwordResetTokens, wishlists, wishlistItems, productSpecifications, type Retailer, type Product, type ProductOffer, type PriceHistory, type WatchList, type ProductWatch, type InsertWatchList, type InsertProductWatch, type InsertRetailer, type InsertProduct, type InsertProductOffer, type InsertPriceHistory, type ProductWithOffers, type SearchFilters, type User, type ForumTopic, type ForumPost, type Wishlist, type WishlistItem, type ProductSpecification, type InsertWishlist, type InsertWishlistItem, type InsertProductSpecification, type WishlistWithItems, type WishlistItemWithProduct, type ProductFull, type SpecificationGroup } from "@shared/schema";
+import { retailers, products, productOffers, priceHistory, watchLists, productWatches, priceAlerts, users, forumTopics, forumPosts, forumCategories, trendingProducts, priceAggregatesWeekly, priceAggregatesMonthly, priceTrends, jobLocks, notifications, passwordResetTokens, wishlists, wishlistItems, productSpecifications, type Retailer, type Product, type ProductOffer, type PriceHistory, type WatchList, type ProductWatch, type InsertWatchList, type InsertProductWatch, type InsertRetailer, type InsertProduct, type InsertProductOffer, type InsertPriceHistory, type ProductWithOffers, type SearchFilters, type User, type ForumTopic, type ForumPost, type Wishlist, type WishlistItem, type ProductSpecification, type InsertWishlist, type InsertWishlistItem, type InsertProductSpecification, type WishlistWithItems, type WishlistItemWithProduct, type ProductFull, type SpecificationGroup, type PasswordResetToken } from "@shared/schema";
 import { db } from "./db";
-import { eq, and, gte, lte, inArray, sql, desc, asc, isNull, or, like } from "drizzle-orm";
+import { eq, and, gte, lte, lt, inArray, sql, desc, asc, isNull, or, like, count } from "drizzle-orm";
 import { retryWithBackoff, isTransientDatabaseError } from "./utils/retry-with-backoff";
 import { logger } from "./utils/logger";
 
@@ -28,6 +28,13 @@ export interface IStorage {
   // Product Offers
   getProductOffers(productId: number): Promise<(ProductOffer & { retailer: Retailer })[]>;
   createProductOffer(offer: InsertProductOffer): Promise<ProductOffer>;
+
+  // Affiliate Link Operations
+  getProductOfferById(offerId: number): Promise<ProductOffer | null>;
+  updateProductOfferAffiliateLink(offerId: number, data: { affiliateUrl: string; linkHealthStatus: 'healthy' | 'broken' | 'unknown'; lastLinkCheck: Date }): Promise<void>;
+  incrementProductOfferClickCount(offerId: number): Promise<void>;
+  getProductOffersByRetailerId(retailerId: number): Promise<ProductOffer[]>;
+  getAffiliateLinkStats(retailerId?: number): Promise<AffiliateLinkStats>;
 
   // Product URL Search (for browser extension)
   getProductByUrl(productUrl: string): Promise<{
@@ -83,6 +90,22 @@ export interface IStorage {
   getMonthlyAggregates(productId: number, options?: { year?: number; month?: number; retailerId?: number; limit?: number }): Promise<MonthlyAggregate[]>;
   getAnalyticsOverview(): Promise<AnalyticsOverview>;
   getJobLocks(): Promise<JobLock[]>;
+
+  // Job Lock Operations
+  acquireJobLock(jobName: string, lockedBy: string, ttlSeconds: number): Promise<{ success: boolean; id?: number }>;
+  getJobLockByName(jobName: string): Promise<JobLock | null>;
+  updateExpiredJobLock(jobName: string, lockedBy: string, newExpiresAt: Date): Promise<{ success: boolean; id?: number }>;
+  releaseJobLock(jobName: string, lockedBy: string): Promise<boolean>;
+  extendJobLock(jobName: string, lockedBy: string, additionalSeconds: number): Promise<boolean>;
+  isJobLocked(jobName: string): Promise<boolean>;
+  cleanupExpiredJobLocks(): Promise<number>;
+
+  // Password Reset Token Operations
+  createPasswordResetToken(userId: number, token: string, expiresAt: Date, metadata?: { ipAddress?: string; userAgent?: string }): Promise<void>;
+  validatePasswordResetToken(token: string): Promise<PasswordResetToken | null>;
+  markPasswordResetTokenAsUsed(token: string): Promise<void>;
+  cleanupExpiredPasswordResetTokens(): Promise<number>;
+  getPasswordResetAttemptCount(userId: number, sinceDate: Date): Promise<number>;
 
   // Forum Operations (with transactions)
   createTopicWithFirstPost(topicData: {
@@ -505,6 +528,57 @@ export class MemStorage implements IStorage {
     return newOffer;
   }
 
+  // Affiliate Link Operations (MemStorage stubs)
+  async getProductOfferById(offerId: number): Promise<ProductOffer | null> {
+    return this.productOffers.get(offerId) ?? null;
+  }
+
+  async updateProductOfferAffiliateLink(
+    offerId: number,
+    data: { affiliateUrl: string; linkHealthStatus: 'healthy' | 'broken' | 'unknown'; lastLinkCheck: Date }
+  ): Promise<void> {
+    const offer = this.productOffers.get(offerId);
+    if (offer) {
+      this.productOffers.set(offerId, {
+        ...offer,
+        affiliateUrl: data.affiliateUrl,
+        linkHealthStatus: data.linkHealthStatus,
+        lastLinkCheck: data.lastLinkCheck
+      });
+    }
+  }
+
+  async incrementProductOfferClickCount(offerId: number): Promise<void> {
+    const offer = this.productOffers.get(offerId);
+    if (offer) {
+      this.productOffers.set(offerId, {
+        ...offer,
+        clickCount: (offer.clickCount ?? 0) + 1
+      });
+    }
+  }
+
+  async getProductOffersByRetailerId(retailerId: number): Promise<ProductOffer[]> {
+    return Array.from(this.productOffers.values()).filter(
+      offer => offer.retailerId === retailerId
+    );
+  }
+
+  async getAffiliateLinkStats(_retailerId?: number): Promise<AffiliateLinkStats> {
+    // Basic in-memory implementation
+    const offers = _retailerId
+      ? Array.from(this.productOffers.values()).filter(o => o.retailerId === _retailerId)
+      : Array.from(this.productOffers.values());
+
+    return {
+      total_offers: offers.length,
+      affiliate_offers: offers.filter(o => o.affiliateUrl).length,
+      total_clicks: offers.reduce((sum, o) => sum + (o.clickCount ?? 0), 0),
+      healthy_links: offers.filter(o => o.linkHealthStatus === 'healthy').length,
+      broken_links: offers.filter(o => o.linkHealthStatus === 'broken').length
+    };
+  }
+
   async getProductByUrl(productUrl: string): Promise<{
     product: Product;
     offer: ProductOffer;
@@ -711,6 +785,56 @@ export class MemStorage implements IStorage {
     return [];
   }
 
+  // Job Lock Operations (stub implementations - job locking not supported in memory storage)
+  async acquireJobLock(_jobName: string, _lockedBy: string, _ttlSeconds: number): Promise<{ success: boolean; id?: number }> {
+    return { success: false };
+  }
+
+  async getJobLockByName(_jobName: string): Promise<JobLock | null> {
+    return null;
+  }
+
+  async updateExpiredJobLock(_jobName: string, _lockedBy: string, _newExpiresAt: Date): Promise<{ success: boolean; id?: number }> {
+    return { success: false };
+  }
+
+  async releaseJobLock(_jobName: string, _lockedBy: string): Promise<boolean> {
+    return false;
+  }
+
+  async extendJobLock(_jobName: string, _lockedBy: string, _additionalSeconds: number): Promise<boolean> {
+    return false;
+  }
+
+  async isJobLocked(_jobName: string): Promise<boolean> {
+    return false;
+  }
+
+  async cleanupExpiredJobLocks(): Promise<number> {
+    return 0;
+  }
+
+  // Password Reset Token Operations (stub implementations)
+  async createPasswordResetToken(_userId: number, _token: string, _expiresAt: Date, _metadata?: { ipAddress?: string; userAgent?: string }): Promise<void> {
+    // Not supported in memory storage
+  }
+
+  async validatePasswordResetToken(_token: string): Promise<PasswordResetToken | null> {
+    return null;
+  }
+
+  async markPasswordResetTokenAsUsed(_token: string): Promise<void> {
+    // Not supported in memory storage
+  }
+
+  async cleanupExpiredPasswordResetTokens(): Promise<number> {
+    return 0;
+  }
+
+  async getPasswordResetAttemptCount(_userId: number, _sinceDate: Date): Promise<number> {
+    return 0;
+  }
+
   // Forum Operations (stub implementations)
   async createTopicWithFirstPost(_topicData: {
     title: string;
@@ -858,6 +982,33 @@ export class DatabaseStorage implements IStorage {
         website: retailer.website || null,
         isActive: retailer.isActive ?? true
       })
+      .returning();
+    return result;
+  }
+
+  async getAllRetailers(): Promise<Retailer[]> {
+    const result = await db.select().from(retailers);
+    return result;
+  }
+
+  async getRetailerById(id: number): Promise<Retailer | undefined> {
+    const [result] = await db.select().from(retailers).where(eq(retailers.id, id)).limit(1);
+    return result;
+  }
+
+  async updateRetailer(id: number, updates: Partial<InsertRetailer>): Promise<Retailer | undefined> {
+    const [result] = await db
+      .update(retailers)
+      .set(updates)
+      .where(eq(retailers.id, id))
+      .returning();
+    return result;
+  }
+
+  async deleteRetailer(id: number): Promise<Retailer | undefined> {
+    const [result] = await db
+      .delete(retailers)
+      .where(eq(retailers.id, id))
       .returning();
     return result;
   }
@@ -1165,6 +1316,70 @@ export class DatabaseStorage implements IStorage {
       })
       .returning();
     return result;
+  }
+
+  // Affiliate Link Operations
+  async getProductOfferById(offerId: number): Promise<ProductOffer | null> {
+    const [offer] = await db
+      .select()
+      .from(productOffers)
+      .where(eq(productOffers.id, offerId))
+      .limit(1);
+    return offer ?? null;
+  }
+
+  async updateProductOfferAffiliateLink(
+    offerId: number,
+    data: { affiliateUrl: string; linkHealthStatus: 'healthy' | 'broken' | 'unknown'; lastLinkCheck: Date }
+  ): Promise<void> {
+    await db
+      .update(productOffers)
+      .set({
+        affiliateUrl: data.affiliateUrl,
+        linkHealthStatus: data.linkHealthStatus,
+        lastLinkCheck: data.lastLinkCheck,
+      })
+      .where(eq(productOffers.id, offerId));
+  }
+
+  async incrementProductOfferClickCount(offerId: number): Promise<void> {
+    await db
+      .update(productOffers)
+      .set({
+        clickCount: sql`COALESCE(${productOffers.clickCount}, 0) + 1`,
+      })
+      .where(eq(productOffers.id, offerId));
+  }
+
+  async getProductOffersByRetailerId(retailerId: number): Promise<ProductOffer[]> {
+    return db
+      .select()
+      .from(productOffers)
+      .where(eq(productOffers.retailerId, retailerId));
+  }
+
+  async getAffiliateLinkStats(retailerId?: number): Promise<AffiliateLinkStats> {
+    const baseQuery = db
+      .select({
+        total_offers: count(),
+        affiliate_offers: sql<number>`COUNT(${productOffers.affiliateUrl})`,
+        total_clicks: sql<number>`COALESCE(SUM(${productOffers.clickCount}), 0)`,
+        healthy_links: sql<number>`COUNT(CASE WHEN ${productOffers.linkHealthStatus} = 'healthy' THEN 1 END)`,
+        broken_links: sql<number>`COUNT(CASE WHEN ${productOffers.linkHealthStatus} = 'broken' THEN 1 END)`,
+      })
+      .from(productOffers);
+
+    const result = retailerId
+      ? await baseQuery.where(eq(productOffers.retailerId, retailerId))
+      : await baseQuery;
+
+    return result[0] || {
+      total_offers: 0,
+      affiliate_offers: 0,
+      total_clicks: 0,
+      healthy_links: 0,
+      broken_links: 0
+    };
   }
 
   /**
@@ -2862,12 +3077,190 @@ export class DatabaseStorage implements IStorage {
       specGroups,
     };
   }
+
+  // Job Lock Operations
+  async acquireJobLock(jobName: string, lockedBy: string, ttlSeconds: number): Promise<{ success: boolean; id?: number }> {
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+    const result = await db
+      .insert(jobLocks)
+      .values({
+        jobName,
+        lockedBy,
+        expiresAt,
+        lockedAt: new Date(),
+      })
+      .onConflictDoNothing()
+      .returning({ id: jobLocks.id });
+
+    return result.length > 0 ? { success: true, id: result[0].id } : { success: false };
+  }
+
+  async getJobLockByName(jobName: string): Promise<JobLock | null> {
+    const [lock] = await db
+      .select()
+      .from(jobLocks)
+      .where(eq(jobLocks.jobName, jobName))
+      .limit(1);
+    return lock ?? null;
+  }
+
+  async updateExpiredJobLock(jobName: string, lockedBy: string, newExpiresAt: Date): Promise<{ success: boolean; id?: number }> {
+    const result = await db
+      .update(jobLocks)
+      .set({
+        lockedBy,
+        lockedAt: new Date(),
+        expiresAt: newExpiresAt,
+      })
+      .where(
+        and(
+          eq(jobLocks.jobName, jobName),
+          lte(jobLocks.expiresAt, new Date())
+        )
+      )
+      .returning({ id: jobLocks.id });
+
+    return result.length > 0 ? { success: true, id: result[0].id } : { success: false };
+  }
+
+  async releaseJobLock(jobName: string, lockedBy: string): Promise<boolean> {
+    const result = await db
+      .delete(jobLocks)
+      .where(
+        and(
+          eq(jobLocks.jobName, jobName),
+          eq(jobLocks.lockedBy, lockedBy)
+        )
+      )
+      .returning({ id: jobLocks.id });
+
+    return result.length > 0;
+  }
+
+  async extendJobLock(jobName: string, lockedBy: string, additionalSeconds: number): Promise<boolean> {
+    const result = await db
+      .update(jobLocks)
+      .set({
+        expiresAt: sql`${jobLocks.expiresAt} + INTERVAL '${sql.raw(additionalSeconds.toString())} seconds'`,
+      })
+      .where(
+        and(
+          eq(jobLocks.jobName, jobName),
+          eq(jobLocks.lockedBy, lockedBy)
+        )
+      )
+      .returning({ id: jobLocks.id });
+
+    return result.length > 0;
+  }
+
+  async isJobLocked(jobName: string): Promise<boolean> {
+    const locks = await db
+      .select({ id: jobLocks.id })
+      .from(jobLocks)
+      .where(
+        and(
+          eq(jobLocks.jobName, jobName),
+          sql`${jobLocks.expiresAt} > NOW()`
+        )
+      )
+      .limit(1);
+
+    return locks.length > 0;
+  }
+
+  async cleanupExpiredJobLocks(): Promise<number> {
+    const result = await db
+      .delete(jobLocks)
+      .where(lte(jobLocks.expiresAt, new Date()))
+      .returning({ id: jobLocks.id });
+
+    return result.length;
+  }
+
+  // Password Reset Token Operations
+  async createPasswordResetToken(
+    userId: number,
+    token: string,
+    expiresAt: Date,
+    metadata?: { ipAddress?: string; userAgent?: string }
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      // Invalidate any existing unused tokens for this user
+      await tx
+        .delete(passwordResetTokens)
+        .where(
+          and(
+            eq(passwordResetTokens.userId, userId),
+            eq(passwordResetTokens.isUsed, false)
+          )
+        );
+
+      // Create the new token
+      await tx.insert(passwordResetTokens).values({
+        userId,
+        token,
+        expiresAt,
+        isUsed: false,
+        ipAddress: metadata?.ipAddress?.substring(0, 45),
+        userAgent: metadata?.userAgent?.substring(0, 500),
+      });
+    });
+  }
+
+  async validatePasswordResetToken(token: string): Promise<PasswordResetToken | null> {
+    const tokenRecord = await db.query.passwordResetTokens.findFirst({
+      where: and(
+        eq(passwordResetTokens.token, token),
+        eq(passwordResetTokens.isUsed, false),
+        sql`${passwordResetTokens.expiresAt} > NOW()`
+      ),
+    });
+    return tokenRecord || null;
+  }
+
+  async markPasswordResetTokenAsUsed(token: string): Promise<void> {
+    await db
+      .update(passwordResetTokens)
+      .set({
+        isUsed: true,
+        usedAt: new Date(),
+      })
+      .where(eq(passwordResetTokens.token, token));
+  }
+
+  async cleanupExpiredPasswordResetTokens(): Promise<number> {
+    const result = await db
+      .delete(passwordResetTokens)
+      .where(lt(passwordResetTokens.expiresAt, new Date()));
+    return result.rowCount || 0;
+  }
+
+  async getPasswordResetAttemptCount(userId: number, sinceDate: Date): Promise<number> {
+    const tokens = await db.query.passwordResetTokens.findMany({
+      where: and(
+        eq(passwordResetTokens.userId, userId),
+        sql`${passwordResetTokens.createdAt} > ${sinceDate}`
+      ),
+    });
+    return tokens.length;
+  }
 }
 
 // Initialize storage - use database when DATABASE_URL is available
 export const storage = process.env.DATABASE_URL
   ? new DatabaseStorage()
   : new MemStorage();
+
+// Job Lock Type
+export interface JobLock {
+  id: number;
+  jobName: string;
+  lockedBy: string;
+  lockedAt: Date;
+  expiresAt: Date;
+  metadata: string | null;
+}
 
 // Price History Types
 export interface PriceHistoryWithDetails extends PriceHistory {
@@ -3023,6 +3416,14 @@ export interface AffiliateConfig {
   commissionRate?: string | null;
   affiliateStatus?: string | null;
   affiliateConfig?: Record<string, unknown> | null;
+}
+
+export interface AffiliateLinkStats {
+  total_offers: number;
+  affiliate_offers: number;
+  total_clicks: number;
+  healthy_links: number;
+  broken_links: number;
 }
 
 // Admin User Types


### PR DESCRIPTION
## Summary

This PR migrates 3 foundation services from direct database access to the storage abstraction layer, addressing architectural issue #031.

### Services Migrated
- **job-lock-service.ts** - Used by scheduled jobs for distributed locking
- **password-reset-service.ts** - Security-critical password reset flow  
- **affiliate-link-service.ts** - Affiliate URL generation and tracking

### Changes Made
- Added 17 new storage methods:
  - 7 job lock methods (acquire, release, extend, cleanup, etc.)
  - 5 password reset token methods (create, validate, mark used, cleanup, rate limiting)
  - 5 affiliate link methods (get/update offers, click tracking, stats)
- Updated services to import `storage` instead of direct `db`
- Removed drizzle-orm query imports from services
- Added TypeScript type exports for new interfaces

### Why This Matters
- **Testability**: Services can now mock `storage` instead of `db`
- **Consistency**: All data access goes through storage layer
- **Maintainability**: Query logic centralized in one place
- **Architecture**: Follows established pattern from CLAUDE.md

### Remaining Work
This is Phase 1 of the migration. 14 services remain to be migrated in future PRs:
- price-history-service, price-aggregation-service, price-snapshot-service
- trend-analysis-service, community-service, notification-service
- smart-notification-service, smart-alerts-service, advanced-search
- monitoring-service, price-drop-detection, product-discovery-fallback
- price-analytics-routes

## Test plan
- [x] TypeScript check passes (291 errors, 2 fewer than main branch)
- [x] Pre-commit hooks pass all security checks
- [ ] Manual verification of job locking behavior
- [ ] Manual verification of password reset flow
- [ ] Manual verification of affiliate link generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)