### PR TITLE
fix: Remove all 'as any' type casts from production code

### DIFF
--- a/client/src/components/optimized/lazy-image.tsx
+++ b/client/src/components/optimized/lazy-image.tsx
@@ -10,16 +10,16 @@ interface LazyImageProps {
   placeholder?: React.ReactNode;
 }
 
-export function LazyImage({ 
-  src, 
-  alt, 
-  className = '', 
+export function LazyImage({
+  src,
+  alt,
+  className = '',
   fallback = '/api/placeholder/300/200',
-  placeholder 
+  placeholder
 }: LazyImageProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
-  const { ref, isIntersecting } = useIntersectionObserver({
+  const { ref, isIntersecting } = useIntersectionObserver<HTMLDivElement>({
     triggerOnce: true,
     rootMargin: '50px',
   });
@@ -37,7 +37,7 @@ export function LazyImage({
   const imageSrc = imageError ? fallback : src;
 
   return (
-    <div ref={ref as any} className={`relative overflow-hidden ${className}`}>
+    <div ref={ref} className={`relative overflow-hidden ${className}`}>
       {shouldLoad ? (
         <>
           <img

--- a/client/src/hooks/use-intersection-observer.ts
+++ b/client/src/hooks/use-intersection-observer.ts
@@ -6,14 +6,14 @@ interface UseIntersectionObserverOptions {
   triggerOnce?: boolean;
 }
 
-export function useIntersectionObserver({
+export function useIntersectionObserver<T extends Element = HTMLElement>({
   threshold = 0,
   rootMargin = '0px',
   triggerOnce = true,
 }: UseIntersectionObserverOptions = {}) {
   const [isIntersecting, setIsIntersecting] = useState(false);
   const [hasTriggered, setHasTriggered] = useState(false);
-  const targetRef = useRef<HTMLElement>(null);
+  const targetRef = useRef<T>(null);
 
   useEffect(() => {
     const target = targetRef.current;

--- a/client/src/hooks/use-intersection-observer.ts
+++ b/client/src/hooks/use-intersection-observer.ts
@@ -6,6 +6,22 @@ interface UseIntersectionObserverOptions {
   triggerOnce?: boolean;
 }
 
+/**
+ * Generic intersection observer hook that detects when an element enters the viewport
+ *
+ * @template T - The element type to observe (defaults to HTMLElement)
+ * @param options - Configuration options for the observer
+ * @returns Object containing a ref for the target element and intersection state
+ *
+ * @example
+ * // For a div element
+ * const { ref, isIntersecting } = useIntersectionObserver<HTMLDivElement>({
+ *   threshold: 0.5,
+ *   triggerOnce: true
+ * });
+ *
+ * return <div ref={ref}>{isIntersecting && <Content />}</div>;
+ */
 export function useIntersectionObserver<T extends Element = HTMLElement>({
   threshold = 0,
   rootMargin = '0px',

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -24,8 +24,9 @@ if (dsn) {
     // Performance Monitoring
     integrations: [
       // Browser tracing for performance monitoring
-      // Note: Using standard browser tracing instead of React Router integration
-      // because we use Wouter (not React Router v6) for routing
+      // Note: Using browserTracingIntegration instead of reactRouterV6BrowserTracingIntegration
+      // because Wouter (lightweight router) doesn't provide React Router v6 hooks.
+      // This still captures page load, navigation timing, and user interactions.
       Sentry.browserTracingIntegration(),
 
       // Session replay for debugging user sessions

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -24,6 +24,8 @@ if (dsn) {
     // Performance Monitoring
     integrations: [
       // Browser tracing for performance monitoring
+      // Note: Using standard browser tracing instead of React Router integration
+      // because we use Wouter (not React Router v6) for routing
       Sentry.browserTracingIntegration(),
 
       // Session replay for debugging user sessions
@@ -31,11 +33,6 @@ if (dsn) {
         maskAllText: false, // Show actual text in replays
         blockAllMedia: false, // Show images/videos in replays
       }),
-
-      // React-specific integration
-      Sentry.reactRouterV6BrowserTracingIntegration({
-        useEffect: React.useEffect,
-      } as any), // Wouter doesn't have official integration, but works with v6 API
     ],
 
     // Tracing - adjust sample rate based on environment


### PR DESCRIPTION
## Summary

Eliminates all `any` type workarounds from production client code by implementing proper TypeScript patterns:

- ✅ **Sentry Integration**: Switched from React Router v6 integration (which required `as any` cast) to standard browser tracing
- ✅ **Intersection Observer**: Made hook generic to support type-safe usage with any Element type
- ✅ **Lazy Image**: Removed `ref as any` cast by using proper generic type parameter

## Changes

### 1. Sentry Integration (`client/src/main.tsx`)
**Before**:
```typescript
Sentry.reactRouterV6BrowserTracingIntegration({
  useEffect: React.useEffect,
} as any), // Wouter doesn't have official integration
```

**After**:
```typescript
// Using standard browser tracing instead of React Router integration
// because we use Wouter (not React Router v6) for routing
Sentry.browserTracingIntegration(),
```

**Why**: We use **Wouter** (not React Router), so the React Router integration required type workarounds. The standard browser tracing integration is the proper solution.

### 2. Intersection Observer Hook (`client/src/hooks/use-intersection-observer.ts`)
**Before**:
```typescript
export function useIntersectionObserver({ ... }) {
  const targetRef = useRef<HTMLElement>(null);
  // ...
}
```

**After**:
```typescript
export function useIntersectionObserver<T extends Element = HTMLElement>({ ... }) {
  const targetRef = useRef<T>(null);
  // ...
}
```

**Why**: Generic type parameter allows type-safe usage with any Element type (div, img, section, etc.).

### 3. Lazy Image Component (`client/src/components/optimized/lazy-image.tsx`)
**Before**:
```typescript
const { ref, isIntersecting } = useIntersectionObserver({...});
return <div ref={ref as any} className={...}>
```

**After**:
```typescript
const { ref, isIntersecting } = useIntersectionObserver<HTMLDivElement>({...});
return <div ref={ref} className={...}>
```

**Why**: Hook now infers proper `HTMLDivElement` type, eliminating the need for `as any` cast.

## Testing

- ✅ TypeScript compilation successful (no errors in modified files)
- ✅ Client build successful (`vite build` completed)
- ✅ Pre-commit hooks passed (including "No 'any' types in new code" check)
- ✅ No `as any` usage remaining in production code

## Impact

- **Type Safety**: Eliminates all type workarounds, enabling TypeScript to catch bugs at compile time
- **Code Quality**: Follows strict TypeScript best practices per `CLAUDE.md`
- **Maintainability**: Proper types make code easier to understand and refactor
- **Pre-commit Compliance**: Satisfies "No `any` types" blocker check

## Related Issues

Addresses GitHub issue #121 (Storage Layer Refactoring) requirement to eliminate `any` types from the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)